### PR TITLE
Added Body field and ensured Value equality is used for all assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ You can optionally include a verbatim body using code blocks surrounded by three
     {"id": 1, "name": "Silk", "release_year": 2016}
     ```
 
+You may also make any number of regex assertions against the body using the `Body` object:
+
+```
+  * Body: /Hello world/
+  * Body: /This should be found too/
+  * Body: /and this/
+```
+
 Alternatively, you can specify a list (using `*`) of data fields to assert accessible via the `Data` object:
 
 ```

--- a/parse/value.go
+++ b/parse/value.go
@@ -39,7 +39,6 @@ func (v Value) String() string {
 // Equal gets whether the Data and specified value are equal.
 // Supports regexp values.
 func (v Value) Equal(val interface{}) bool {
-	// check to see if this is regex
 	var str string
 	var ok bool
 	if str, ok = v.Data.(string); !ok {
@@ -63,7 +62,7 @@ func (v Value) Type() string {
 	if str, ok = v.Data.(string); !ok {
 		return fmt.Sprintf("%T", v.Data)
 	}
-	if strings.HasPrefix(str, "/") && strings.HasSuffix(str, "/") {
+	if isRegex(str) {
 		return "regex"
 	}
 	return "string"

--- a/parse/value.go
+++ b/parse/value.go
@@ -13,11 +13,22 @@ func (e errValue) Error() string {
 	return fmt.Sprintf("invalid value: %s (did you forget quotes?)", string(e))
 }
 
+func isRegex(v interface{}) bool {
+	s, ok := v.(string)
+	if !ok {
+		return false
+	}
+	return strings.HasPrefix(s, `/`) && strings.HasSuffix(s, `/`)
+}
+
 type Value struct {
 	Data interface{}
 }
 
 func (v Value) String() string {
+	if isRegex(v.Data) {
+		return v.Data.(string)
+	}
 	b, err := json.Marshal(v.Data)
 	if err != nil {
 		panic("silk: cannot marshal value: \"" + fmt.Sprintf("%v", v.Data) + "\": " + err.Error())
@@ -34,7 +45,7 @@ func (v Value) Equal(val interface{}) bool {
 	if str, ok = v.Data.(string); !ok {
 		return v.Data == val
 	}
-	if strings.HasPrefix(str, "/") && strings.HasSuffix(str, "/") {
+	if isRegex(str) {
 		// looks like regexp to me
 		regex := regexp.MustCompile(str[1 : len(str)-1])
 		// turn the value into a string

--- a/parse/value_test.go
+++ b/parse/value_test.go
@@ -49,5 +49,6 @@ func TestValueEqual(t *testing.T) {
 	is.True(v.Equal("text/xml; application/json; charset=utf-8"))
 	is.False(v.Equal("text/xml; charset=utf-8"))
 	is.Equal("regex", v.Type())
+	is.Equal(`/application/json/`, v.String())
 
 }

--- a/parse/value_test.go
+++ b/parse/value_test.go
@@ -51,4 +51,8 @@ func TestValueEqual(t *testing.T) {
 	is.Equal("regex", v.Type())
 	is.Equal(`/application/json/`, v.String())
 
+	v = ParseValue([]byte("/Silk/"))
+	is.True(v.Equal("My name is Silk."))
+	is.True(v.Equal("Silk is my name."))
+	is.False(v.Equal("I don't contain that word!"))
 }

--- a/runner/run.go
+++ b/runner/run.go
@@ -240,7 +240,7 @@ func (r *Runner) assertBody(actual, expected []byte) bool {
 }
 
 func (r *Runner) assertDetail(key string, actual interface{}, expected *parse.Value) bool {
-	if actual != expected.Data {
+	if !expected.Equal(actual) {
 		actualVal := parse.ParseValue([]byte(fmt.Sprintf("%v", actual)))
 		r.log(key, fmt.Sprintf("expected %s: %s  actual %T: %s", expected.Type(), expected, actual, actualVal))
 		return false

--- a/runner/run.go
+++ b/runner/run.go
@@ -172,6 +172,9 @@ func (r *Runner) runRequest(group *parse.Group, req *parse.Request) {
 		r.t.FailNow()
 		return
 	}
+	
+	// set the body as a field (see issue #15)
+	responseDetails["Body"] = string(actualBody)
 
 	// assert the body
 	if len(req.ExpectedBody) > 0 {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -51,6 +51,16 @@ func TestData(t *testing.T) {
 	is.False(subT.Failed())
 }
 
+func TestBodyField(t *testing.T) {
+	is := is.New(t)
+	subT := &testT{}
+	s := httptest.NewServer(testutil.EchoDataHandler())
+	defer s.Close()
+	r := runner.New(subT, s.URL)
+	r.RunFile("../testfiles/success/body.silk.md")
+	is.False(subT.Failed())
+}
+
 func TestRunFileSuccessNoBody(t *testing.T) {
 	is := is.New(t)
 	subT := &testT{}

--- a/testfiles/success/body.silk.md
+++ b/testfiles/success/body.silk.md
@@ -15,4 +15,4 @@
 
 * `Server`: `"EchoDataHandler"`
 * `Status`: `200`
-* `Body`: `/Silk/`
+* `Body`: /Silk/

--- a/testfiles/success/body.silk.md
+++ b/testfiles/success/body.silk.md
@@ -1,0 +1,18 @@
+# Echo server
+
+## GET /echo
+
+* `Content-Type`: `"application/json"`
+* `X-Another-Header`: `"value"`
+
+```
+{"name":"Silk","status":"awesome","a_bool":true,"nothing":null,"release_year":2016}
+```
+
+===
+
+### Response
+
+* `Server`: `"EchoDataHandler"`
+* `Status`: `200`
+* `Body`: `/Silk/`


### PR DESCRIPTION
Value equality (in run.go) ensures that regex can be used on all assertions, not just `Data` ones.