### PR TITLE
Change assertDetail to only show field type when they differ

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -243,7 +243,13 @@ func (r *Runner) assertBody(actual, expected []byte) bool {
 func (r *Runner) assertDetail(key string, actual interface{}, expected *parse.Value) bool {
 	if !expected.Equal(actual) {
 		actualVal := parse.ParseValue([]byte(fmt.Sprintf("%v", actual)))
-		r.log(key, fmt.Sprintf("expected %s: %s  actual %T: %s", expected.Type(), expected, actual, actualVal))
+
+		if expected.Type() == actualVal.Type() {
+			r.log(key, fmt.Sprintf("expected: %s  actual: %s", expected, actualVal))
+		} else {
+			r.log(key, fmt.Sprintf("expected %s: %s  actual %T: %s", expected.Type(), expected, actual, actualVal))
+		}
+
 		return false
 	}
 	return true

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -111,7 +111,8 @@ func TestFailureWrongHeader(t *testing.T) {
 	r.RunGroup(g...)
 	is.True(subT.Failed())
 	logstr := strings.Join(logs, "\n")
-	is.True(strings.Contains(logstr, `Content-Type expected string: "wrong/type"  actual string: "text/plain; charset=utf-8"`))
+
+	is.True(strings.Contains(logstr, `Content-Type expected: "wrong/type"  actual: "text/plain; charset=utf-8"`))
 	is.True(strings.Contains(logstr, "--- FAIL: GET /echo"))
 	is.True(strings.Contains(logstr, "../testfiles/failure/echo.failure.wrongheader.silk.md:22 - Content-Type doesn't match"))
 }
@@ -125,6 +126,44 @@ func TestGlob(t *testing.T) {
 	r.Log = func(s string) {} // don't bother logging
 	r.RunGlob(filepath.Glob("../testfiles/failure/*.silk.md"))
 	is.True(subT.Failed())
+}
+
+func TestFailureFieldsSameType(t *testing.T) {
+	is := is.New(t)
+	subT := &testT{}
+	s := httptest.NewServer(testutil.EchoHandler())
+	defer s.Close()
+	r := runner.New(subT, s.URL)
+	var logs []string
+	r.Log = func(s string) {
+		logs = append(logs, s)
+	}
+	g, err := parse.ParseFile("../testfiles/failure/echo.failure.fieldssametype.silk.md")
+	is.NoErr(err)
+	r.RunGroup(g...)
+	is.True(subT.Failed())
+	logstr := strings.Join(logs, "\n")
+
+	is.True(strings.Contains(logstr, "Status expected: 400  actual: 200"))
+}
+
+func TestFailureFieldsDifferentTypes(t *testing.T) {
+	is := is.New(t)
+	subT := &testT{}
+	s := httptest.NewServer(testutil.EchoHandler())
+	defer s.Close()
+	r := runner.New(subT, s.URL)
+	var logs []string
+	r.Log = func(s string) {
+		logs = append(logs, s)
+	}
+	g, err := parse.ParseFile("../testfiles/failure/echo.failure.fieldsdifferenttypes.silk.md")
+	is.NoErr(err)
+	r.RunGroup(g...)
+	is.True(subT.Failed())
+	logstr := strings.Join(logs, "\n")
+
+	is.True(strings.Contains(logstr, `Status expected string: "400"  actual float64: 200`))
 }
 
 type testT struct {

--- a/testfiles/failure/echo.failure.fieldsdifferenttypes.silk.md
+++ b/testfiles/failure/echo.failure.fieldsdifferenttypes.silk.md
@@ -1,0 +1,7 @@
+# Echo server
+
+## GET /echo
+
+===
+
+* Status: "400"

--- a/testfiles/failure/echo.failure.fieldssametype.silk.md
+++ b/testfiles/failure/echo.failure.fieldssametype.silk.md
@@ -1,0 +1,7 @@
+# Echo server
+
+## GET /echo
+
+===
+
+* Status: 400


### PR DESCRIPTION
Issue #16

Added logic to assertDetail to show a less verbose message (not including field types) when an expected and actual are the same type. If they differ then the field type is still shown.