### PR TITLE
Improve handling of json bodies during validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,23 @@ To assert that a cookie is present in a response, make a regex assertion against
 You can optionally include a verbatim body using code blocks surrounded by three back tics. If the response body does not exactly match, the test will fail:
 
     ```
-    {"id": 1, "name": "Silk", "release_year": 2016}
+    Hello world!
     ```
+
+You can flag expected response bodies as `json` directly after the three back tics. 
+This will assert that the actual response contains the same value for each expected key (recursively)
+allowing for differences in whitespace and ordering as well as being lenient towards additional (unexpected) keys in the response. 
+
+    ```json
+    {
+        "id": 1, 
+        "release_year": 2016,
+        "name": "Silk"
+    }
+    ```
+
+You can use the flag `json(mode=same)` to enforce that no additional fields may be present while still allowing for differences in whitespace and key order.
+Finally `json(mode=exact)` matches the expected body verbatim.
 
 You may also make any number of regex assertions against the body using the `Body` object:
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ You can optionally include a verbatim body using code blocks surrounded by three
     Hello world!
     ```
 
-You can flag expected response bodies as `json` directly after the three back tics. 
+You can flag expected response bodies as `json` directly after the three back tics.
 This will assert that the actual response contains the same value for each expected key (recursively)
-allowing for differences in whitespace and ordering as well as being lenient towards additional (unexpected) keys in the response. 
+allowing for differences in whitespace and ordering as well as being lenient towards additional (unexpected) keys in the response.
 
     ```json
     {
@@ -164,8 +164,7 @@ allowing for differences in whitespace and ordering as well as being lenient tow
     }
     ```
 
-You can use the flag `json(mode=same)` to enforce that no additional fields may be present while still allowing for differences in whitespace and key order.
-Finally `json(mode=exact)` matches the expected body verbatim.
+You can use the flag `json(strict)` to enforce that no additional fields may be present while still allowing for differences in whitespace and key order.
 
 You may also make any number of regex assertions against the body using the `Body` object:
 

--- a/runner/run.go
+++ b/runner/run.go
@@ -221,20 +221,18 @@ func (r *Runner) runRequest(group *parse.Group, req *parse.Request) {
 
 		// depending on the expectedBodyType:
 		// json*: check if expectedBody as JSON is a subset of the actualBody as json
-		// json(mode=same): check JSON for deep equality (avoids checking diffs in white space and order)
-		// json(mode=exact): check string for verbatim equality
+		// json(exact): check JSON for deep equality (avoids checking diffs in white space and order)
 		// *: check string for verbatim equality
 
 		expectedTypeIsJSON := strings.HasPrefix(req.ExpectedBodyType, "json")
-		modeIsExact := strings.Contains(req.ExpectedBodyType, "mode=exact")
-		if expectedTypeIsJSON && !modeIsExact {
+		if expectedTypeIsJSON {
 			// decode json from string
 			var expectedJSON interface{}
 			var actualJSON interface{}
 			json.Unmarshal([]byte(exp), &expectedJSON)
 			json.Unmarshal(actualBody, &actualJSON)
 
-			if !strings.Contains(req.ExpectedBodyType, "same") {
+			if !strings.Contains(req.ExpectedBodyType, "exact") {
 				eq, err := r.assertJSONIsEqualOrSubset(expectedJSON, actualJSON)
 				if !eq {
 					r.fail(group, req, req.ExpectedBody.Number(), "- body doesn't match", err)

--- a/runner/run.go
+++ b/runner/run.go
@@ -373,7 +373,13 @@ func (r *Runner) assertData(line *parse.Line, data interface{}, errData error, k
 // or if both are maps (of type map[string]interface{}) and v1 is a subset of v2, where
 // all keys that are present in v1 are present with the same value in v2.
 func (r *Runner) assertJSONIsEqualOrSubset(v1 interface{}, v2 interface{}) (bool, error) {
-	if reflect.ValueOf(v1).Type() != reflect.ValueOf(v2).Type() {
+	if (v1 == nil) && (v2 == nil) {
+		return true, nil
+	}
+
+	// check if both are non nil and that type matches
+	if ((v1 == nil) != (v2 == nil)) ||
+		(reflect.ValueOf(v1).Type() != reflect.ValueOf(v2).Type()) {
 		return false, fmt.Errorf("types do not match")
 	}
 

--- a/runner/run.go
+++ b/runner/run.go
@@ -218,13 +218,16 @@ func (r *Runner) runRequest(group *parse.Group, req *parse.Request) {
 	if len(req.ExpectedBody) > 0 {
 		// check body against expected body
 		exp := r.resolveVars(req.ExpectedBody.String())
-		/*
-			depending on the expectedBodyType:
-			json(mode=subset): check if expectedBody as JSON is a subset of the actualBody as json
-			json*: check JSON for deep equality (avoids checking diffs in white space and order)
-			*: check string for equality
-		*/
-		if strings.HasPrefix(req.ExpectedBodyType, "json") {
+
+		// depending on the expectedBodyType:
+		// json*: check JSON for deep equality (avoids checking diffs in white space and order)
+		// json(mode=subset): check if expectedBody as JSON is a subset of the actualBody as json
+		// json(mode=exact): check string for verbatim equality
+		// *: check string for verbatim equality
+
+		expectedTypeIsJSON := strings.HasPrefix(req.ExpectedBodyType, "json")
+		modeIsExact := strings.Contains(req.ExpectedBodyType, "mode=exact")
+		if expectedTypeIsJSON && !modeIsExact {
 			// decode json from string
 			var expectedJSON interface{}
 			var actualJSON interface{}

--- a/runner/run.go
+++ b/runner/run.go
@@ -220,8 +220,8 @@ func (r *Runner) runRequest(group *parse.Group, req *parse.Request) {
 		exp := r.resolveVars(req.ExpectedBody.String())
 
 		// depending on the expectedBodyType:
-		// json*: check JSON for deep equality (avoids checking diffs in white space and order)
-		// json(mode=subset): check if expectedBody as JSON is a subset of the actualBody as json
+		// json*: check if expectedBody as JSON is a subset of the actualBody as json
+		// json(mode=same): check JSON for deep equality (avoids checking diffs in white space and order)
 		// json(mode=exact): check string for verbatim equality
 		// *: check string for verbatim equality
 
@@ -234,7 +234,7 @@ func (r *Runner) runRequest(group *parse.Group, req *parse.Request) {
 			json.Unmarshal([]byte(exp), &expectedJSON)
 			json.Unmarshal(actualBody, &actualJSON)
 
-			if strings.Contains(req.ExpectedBodyType, "subset") {
+			if !strings.Contains(req.ExpectedBodyType, "same") {
 				eq, err := r.assertJSONIsEqualOrSubset(expectedJSON, actualJSON)
 				if !eq {
 					r.fail(group, req, req.ExpectedBody.Number(), "- body doesn't match", err)
@@ -384,7 +384,7 @@ func (r *Runner) assertJSONIsEqualOrSubset(v1 interface{}, v2 interface{}) (bool
 		v2map := v2.(map[string]interface{})
 		for objK, objV := range v1.(map[string]interface{}) {
 			if v2map[objK] == nil {
-				return false, fmt.Errorf("missing key %s", objK)
+				return false, fmt.Errorf("missing key '%s'", objK)
 			}
 			equalForKey, errForKey := r.assertJSONIsEqualOrSubset(objV, v2map[objK])
 			if !equalForKey {

--- a/runner/run.go
+++ b/runner/run.go
@@ -218,14 +218,26 @@ func (r *Runner) runRequest(group *parse.Group, req *parse.Request) {
 	if len(req.ExpectedBody) > 0 {
 		// check body against expected body
 		exp := r.resolveVars(req.ExpectedBody.String())
-		// check JSON for deep equality (avoids checking diffs in white space and order)
-		// check string for equality
-		if req.ExpectedBodyType == "json" {
+		/*
+			depending on the expectedBodyType:
+			json(mode=subset): check if expectedBody as JSON is a subset of the actualBody as json
+			json*: check JSON for deep equality (avoids checking diffs in white space and order)
+			*: check string for equality
+		*/
+		if strings.HasPrefix(req.ExpectedBodyType, "json") {
+			// decode json from string
 			var expectedJSON interface{}
 			var actualJSON interface{}
 			json.Unmarshal([]byte(exp), &expectedJSON)
 			json.Unmarshal(actualBody, &actualJSON)
-			if !reflect.DeepEqual(actualJSON, expectedJSON) {
+
+			if strings.Contains(req.ExpectedBodyType, "subset") {
+				eq, err := r.assertJSONIsEqualOrSubset(expectedJSON, actualJSON)
+				if !eq {
+					r.fail(group, req, req.ExpectedBody.Number(), "- body doesn't match", err)
+					return
+				}
+			} else if !reflect.DeepEqual(actualJSON, expectedJSON) {
 				r.fail(group, req, req.ExpectedBody.Number(), "- body doesn't match")
 				return
 			}
@@ -352,6 +364,39 @@ func (r *Runner) assertData(line *parse.Line, data interface{}, errData error, k
 		return false
 	}
 	return true
+}
+
+// assertJSONIsEqualOrSubset returns true if v1 and v2 are equal in value
+// or if both are maps (of type map[string]interface{}) and v1 is a subset of v2, where
+// all keys that are present in v1 are present with the same value in v2.
+func (r *Runner) assertJSONIsEqualOrSubset(v1 interface{}, v2 interface{}) (bool, error) {
+	if reflect.ValueOf(v1).Type() != reflect.ValueOf(v2).Type() {
+		return false, fmt.Errorf("types do not match")
+	}
+
+	switch v1.(type) {
+	case map[string]interface{}:
+		// recursively check maps
+		// v2 is of same type as v1 as check in early return
+		v2map := v2.(map[string]interface{})
+		for objK, objV := range v1.(map[string]interface{}) {
+			if v2map[objK] == nil {
+				return false, fmt.Errorf("missing key %s", objK)
+			}
+			equalForKey, errForKey := r.assertJSONIsEqualOrSubset(objV, v2map[objK])
+			if !equalForKey {
+				return false, fmt.Errorf("mismatch for key '%s': %s", objK, errForKey)
+			}
+		}
+
+		return true, nil
+	default:
+		// all non-map types must be deep equal
+		if !reflect.DeepEqual(v1, v2) {
+			return false, fmt.Errorf("values do not match - %s != %s", v1, v2)
+		}
+		return true, nil
+	}
 }
 
 func (r *Runner) capture(key string, val interface{}) {

--- a/runner/run_test.go
+++ b/runner/run_test.go
@@ -148,7 +148,7 @@ func TestGlob(t *testing.T) {
 	defer s.Close()
 	r := runner.New(subT, s.URL)
 	r.Log = func(s string) {} // don't bother logging
-	r.RunGlob(filepath.Glob("../testfiles/failure/*.silk.md"))
+	r.RunGlob(filepath.Glob("../testfiles/failure/echo.*.silk.md"))
 	is.True(subT.Failed())
 }
 
@@ -198,6 +198,30 @@ func TestFailureFieldsDifferentTypes(t *testing.T) {
 	logstr := strings.Join(logs, "\n")
 
 	is.True(strings.Contains(logstr, `Status expected string: "400"  actual float64: 200`))
+}
+
+func TestRunJsonModesSuccess(t *testing.T) {
+	is := is.New(t)
+	subT := &testT{}
+	s := httptest.NewServer(testutil.EchoRawHandler())
+	defer s.Close()
+	r := runner.New(subT, s.URL)
+	g, err := parse.ParseFile("../testfiles/success/echoraw.success.jsonmodes.silk.md")
+	is.NoErr(err)
+	r.RunGroup(g...)
+	is.False(subT.Failed())
+}
+
+func TestRunJsonModesFailure(t *testing.T) {
+	is := is.New(t)
+	subT := &testT{}
+	s := httptest.NewServer(testutil.EchoRawHandler())
+	defer s.Close()
+	r := runner.New(subT, s.URL)
+	g, err := parse.ParseFile("../testfiles/failure/echoraw.failure.jsonmodes.silk.md")
+	is.NoErr(err)
+	r.RunGroup(g...)
+	is.True(subT.Failed())
 }
 
 type testT struct {

--- a/testfiles/failure/echoraw.failure.jsonmodes.silk.md
+++ b/testfiles/failure/echoraw.failure.jsonmodes.silk.md
@@ -9,33 +9,6 @@ The server echos the request's body directly.
 ### Example request
 
 ```json
-{ "name": "Mat", "meta" : { "client" : "tester" } }
-```
-
-===
-
-### Example response
-
-* `Status`: `200`
-
-Use the json qualifier in your expected request body to allow differences in order and white space.
-
-```json
-{
-  "comment": "Good work",
-  "name":    "Mat",
-  "meta" : {
-    "client" : "tester"
-  }
-}
-```
-## `GET /json/subset`
-
-Create a comment.
-
-### Example request
-
-```json
 { "name": "Mat",  "comment": "Good work", "meta" : { "api" : 1.0 } }
 ```
 
@@ -45,13 +18,41 @@ Create a comment.
 
 * `Status`: `200`
 
-Use the `json(mode=subset)` qualifier in your expected request body to only check for
+By defaul using the `json` qualifier in your expected request body only checks for
 a subset of the response. This allows you to scope your tests or to be more lenient
-towards future unrelated changes.
+towards future unrelated changes. Additional fields in the response do not invalidate
+the test.
 
-```json(mode=subset)
+```json
 {
   "name":    "Mat",
   "meta" : { "client" : "tester" }
+}
+```
+
+## `GET /json/same`
+
+### Example request
+
+```json
+{ "name": "Mat", "meta" : { "client" : "tester" } }
+```
+
+===
+
+### Example response
+
+* `Status`: `200`
+
+Use the `json(mode=same)` qualifier in your expected request body to ensure that the json object are the same.
+This allows differences in order and white space.
+
+```json(mode=same)
+{
+  "comment": "Good work",
+  "name":    "Mat",
+  "meta" : {
+    "client" : "tester"
+  }
 }
 ```

--- a/testfiles/failure/echoraw.failure.jsonmodes.silk.md
+++ b/testfiles/failure/echoraw.failure.jsonmodes.silk.md
@@ -44,10 +44,10 @@ the test.
 
 * `Status`: `200`
 
-Use the `json(mode=same)` qualifier in your expected request body to ensure that the json object are the same.
+Use the `json(strict)` qualifier in your expected request body to ensure that the json object are the same.
 This allows differences in order and white space.
 
-```json(mode=same)
+```json(strict)
 {
   "comment": "Good work",
   "name":    "Mat",

--- a/testfiles/failure/echoraw.failure.jsonmodes.silk.md
+++ b/testfiles/failure/echoraw.failure.jsonmodes.silk.md
@@ -1,0 +1,57 @@
+# Comments and things
+
+* Root: "http://localhost:8080/"
+
+The server echos the request's body directly.
+
+## `GET /json`
+
+### Example request
+
+```json
+{ "name": "Mat", "meta" : { "client" : "tester" } }
+```
+
+===
+
+### Example response
+
+* `Status`: `200`
+
+Use the json qualifier in your expected request body to allow differences in order and white space.
+
+```json
+{
+  "comment": "Good work",
+  "name":    "Mat",
+  "meta" : {
+    "client" : "tester"
+  }
+}
+```
+## `GET /json/subset`
+
+Create a comment.
+
+### Example request
+
+```json
+{ "name": "Mat",  "comment": "Good work", "meta" : { "api" : 1.0 } }
+```
+
+===
+
+### Example response
+
+* `Status`: `200`
+
+Use the `json(mode=subset)` qualifier in your expected request body to only check for
+a subset of the response. This allows you to scope your tests or to be more lenient
+towards future unrelated changes.
+
+```json(mode=subset)
+{
+  "name":    "Mat",
+  "meta" : { "client" : "tester" }
+}
+```

--- a/testfiles/success/echoraw.success.jsonmodes.silk.md
+++ b/testfiles/success/echoraw.success.jsonmodes.silk.md
@@ -44,10 +44,10 @@ the test.
 
 * `Status`: `200`
 
-Use the `json(mode=same)` qualifier in your expected request body to ensure that the json object are the same.
+Use the `json(strict)` qualifier in your expected request body to ensure that the json object are the same.
 This allows differences in order and white space.
 
-```json
+```json(strict)
 {
   "comment": "Good work",
   "name":    "Mat",

--- a/testfiles/success/echoraw.success.jsonmodes.silk.md
+++ b/testfiles/success/echoraw.success.jsonmodes.silk.md
@@ -9,33 +9,6 @@ The server echos the request's body directly.
 ### Example request
 
 ```json
-{ "name": "Mat",  "comment": "Good work", "meta" : { "client" : "tester" } }
-```
-
-===
-
-### Example response
-
-* `Status`: `200`
-
-Use the json qualifier in your expected request body to allow differences in order and white space.
-
-```json
-{
-  "comment": "Good work",
-  "name":    "Mat",
-  "meta" : {
-    "client" : "tester"
-  }
-}
-```
-## `GET /json/subset`
-
-Create a comment.
-
-### Example request
-
-```json
 { "name": "Mat",  "comment": "Good work", "meta" : { "client" : "tester", "api" : 1.0 } }
 ```
 
@@ -45,13 +18,41 @@ Create a comment.
 
 * `Status`: `200`
 
-Use the `json(mode=subset)` qualifier in your expected request body to only check for
+By defaul using the `json` qualifier in your expected request body only checks for
 a subset of the response. This allows you to scope your tests or to be more lenient
-towards future unrelated changes.
+towards future unrelated changes. Additional fields in the response do not invalidate
+the test.
 
-```json(mode=subset)
+```json
 {
   "name":    "Mat",
   "meta" : { "client" : "tester" }
+}
+```
+
+## `GET /json/same`
+
+### Example request
+
+```json
+{ "name": "Mat",  "comment": "Good work", "meta" : { "client" : "tester" } }
+```
+
+===
+
+### Example response
+
+* `Status`: `200`
+
+Use the `json(mode=same)` qualifier in your expected request body to ensure that the json object are the same.
+This allows differences in order and white space.
+
+```json
+{
+  "comment": "Good work",
+  "name":    "Mat",
+  "meta" : {
+    "client" : "tester"
+  }
 }
 ```

--- a/testfiles/success/echoraw.success.jsonmodes.silk.md
+++ b/testfiles/success/echoraw.success.jsonmodes.silk.md
@@ -1,0 +1,57 @@
+# Comments and things
+
+* Root: "http://localhost:8080/"
+
+The server echos the request's body directly.
+
+## `GET /json`
+
+### Example request
+
+```json
+{ "name": "Mat",  "comment": "Good work", "meta" : { "client" : "tester" } }
+```
+
+===
+
+### Example response
+
+* `Status`: `200`
+
+Use the json qualifier in your expected request body to allow differences in order and white space.
+
+```json
+{
+  "comment": "Good work",
+  "name":    "Mat",
+  "meta" : {
+    "client" : "tester"
+  }
+}
+```
+## `GET /json/subset`
+
+Create a comment.
+
+### Example request
+
+```json
+{ "name": "Mat",  "comment": "Good work", "meta" : { "client" : "tester", "api" : 1.0 } }
+```
+
+===
+
+### Example response
+
+* `Status`: `200`
+
+Use the `json(mode=subset)` qualifier in your expected request body to only check for
+a subset of the response. This allows you to scope your tests or to be more lenient
+towards future unrelated changes.
+
+```json(mode=subset)
+{
+  "name":    "Mat",
+  "meta" : { "client" : "tester" }
+}
+```

--- a/testutil/echo.go
+++ b/testutil/echo.go
@@ -25,6 +25,11 @@ func EchoDataHandler() http.Handler {
 	return http.HandlerFunc(handleEchoData)
 }
 
+// EchoRawHandler gets an http.Handler that echos request's body only.
+func EchoRawHandler() http.Handler {
+	return http.HandlerFunc(handleEchoRaw)
+}
+
 func handleEcho(w http.ResponseWriter, r *http.Request) {
 	// set Server header
 	w.Header().Set("Server", "EchoHandler")
@@ -86,6 +91,21 @@ func handleEchoData(w http.ResponseWriter, r *http.Request) {
 	out["body"] = bodyData
 	if err := json.NewEncoder(w).Encode(out); err != nil {
 		panic(err)
+	}
+}
+
+func handleEchoRaw(w http.ResponseWriter, r *http.Request) {
+	// set Server header
+	w.Header().Set("Server", "EchoRawHandler")
+
+	// read body
+	var bodybuf bytes.Buffer
+	if _, err := io.Copy(&bodybuf, r.Body); err != nil {
+		log.Println("copying request into buffer failed:", err)
+	}
+	// write body
+	if _, err := io.Copy(w, &bodybuf); err != nil {
+		log.Println("copying request into response failed:", err)
 	}
 }
 


### PR DESCRIPTION
This uses the type annotation in the expected body to perform a deepEqual comparison on the deserialized JSON.

This PR implements `json` (defaults to mode=same) and `json(mode=subset)` as discussed in #25.

 I did not have the time yet to add appropriate unit tests, but will happily do so before merging this PR.